### PR TITLE
Pre-populate MQ Light data during build

### DIFF
--- a/early-access/Dockerfile
+++ b/early-access/Dockerfile
@@ -16,20 +16,32 @@ FROM ubuntu:12.04
 
 MAINTAINER Arthur Barr <arthur.barr@uk.ibm.com>
 
-RUN export DEBIAN_FRONTEND=noninteractive && \
-	MQLIGHT_URL=http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqkoa/IBM-MQ-Light-Linux-x64-early-access-L150205.1.tar.gz  && \
-	apt-get update -y && \
-	apt-get install -y curl tar bash net-tools && \
-	mkdir -p /opt/mqlight && \
-	curl -sL $MQLIGHT_URL | tar -zx --strip-components 1 -C /opt/mqlight
-	
+ENV MQLIGHT_DATA_PATH /var/mqlight
+
 COPY mqlight /usr/local/bin/
 
-RUN chmod +x /usr/local/bin/mqlight
+RUN chmod +x /usr/local/bin/mqlight && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -y && apt-get install -y \
+        bash \
+        curl \
+        net-tools \
+        tar && \
+    mkdir -p /opt/mqlight /var/mqlight && \
+    MQLIGHT_URL=https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqkoa && \
+    MQLIGHT_PKG=IBM-MQ-Light-Linux-x64-early-access-L150205.1.tar.gz && \
+    curl -sL $MQLIGHT_URL/$MQLIGHT_PKG | tar -zx --strip-components 1 -C /opt/mqlight && \
+    /usr/local/bin/mqlight initialize && \
+    apt-get --purge remove --auto-remove curl -y && \
+    apt-get clean autoclean -y && \
+    rm -rf /tmp/* \
+        /var/cache/apt/* \
+        /var/lib/apt/lists/* \
+        /var/lib/cache/* \
+        /var/lib/log/* \
+        /var/tmp/*
 
-VOLUME /var/mqlight
-
-ENV MQLIGHT_DATA_PATH /var/mqlight
+VOLUME ${MQLIGHT_DATA_PATH}
 
 EXPOSE 5672 5671 9180 9181
 

--- a/early-access/mqlight
+++ b/early-access/mqlight
@@ -17,22 +17,9 @@
 set -e
 
 INSTALL_DIR=/opt/mqlight
+CACHE_FILE=/var/cache/mqlight-data.tar.gz
 export PATH=$PATH:$INSTALL_DIR:$INSTALL_DIR/runtime/bin
 CONFIG=""
-
-licenseCheck()
-{
-	if [ "$LICENSE" = "accept" ]; then
-		CONFIG="$CONFIG --accept-license"
-		return
-	elif [ "$LICENSE" = "view" ]; then
-		mqlight-config --show-license
-		exit 1
-	else
-		echo -e "Set environment variable LICENSE=accept to indicate acceptance of license terms and conditions.\n\nLicense agreements and information can be viewed by running this image with the environment variable LICENSE=view."
-		exit 2
-	fi
-}
 
 config()
 {
@@ -49,16 +36,40 @@ config()
 		CONFIG="$CONFIG --ssl-keystore $MQLIGHT_TLS_KEYSTORE"
 	fi
 }
-	
-stop()
+
+initialize()
 {
+	set -x
+	export AMQ_INHIBIT_O_DIRECT=TRUE
+	mqlight-config -v
+	mqlight-config --accept-license
+	mqlight-start --no-browser
 	mqlight-stop
-	dspmq
-	exit
+	rm -rf $MQLIGHT_DATA_PATH/mqm/.lapc
+	GZIP=-9 tar zcf $CACHE_FILE -C $MQLIGHT_DATA_PATH .
+	rm -rf $MQLIGHT_DATA_PATH
+	mkdir $MQLIGHT_DATA_PATH
+}
+
+licenseCheck()
+{
+	if [ "$LICENSE" = "accept" ]; then
+		CONFIG="$CONFIG --accept-license"
+		return
+	elif [ "$LICENSE" = "view" ]; then
+		mqlight-config --show-license
+		exit 1
+	else
+		echo -e "Set environment variable LICENSE=accept to indicate acceptance of license terms and conditions.\n\nLicense agreements and information can be viewed by running this image with the environment variable LICENSE=view."
+		exit 2
+	fi
 }
 
 monitor()
 {
+	echo "----------------------------------------"
+	echo "Monitoring MQ Light..."
+
 	# Loop until "dspmq" says the queue manager is running
 	until [ "`dspmq -n | cut -f3 -d"("`" == "RUNNING)" ]; do
 		sleep 1
@@ -72,10 +83,40 @@ monitor()
 	dspmq
 }
 
-licenseCheck
-config
-( set -x ; mqlight-config -v ; mqlight-config $CONFIG ; mqlight-start )
-echo "----------------------------------------"
-echo "Monitoring MQ Light..."
-trap stop SIGTERM SIGINT
-monitor
+runmqras()
+{
+	echo "$INSTALL_DIR/runtime/bin/runmqras -section all -outputdir $MQLIGHT_DATA_PATH/mqm/errors"
+	$INSTALL_DIR/runtime/bin/runmqras -section all -outputdir $MQLIGHT_DATA_PATH/mqm/errors
+}
+
+start()
+{
+	if [ ! -f $MQLIGHT_DATA_PATH/mqm/mqs.ini ]; then
+		if [ -n "$MQLIGHT_REGENERATE_DATA" ]; then
+			echo "Reinitializing IBM MQ Light"
+		else
+			echo "Initializing IBM MQ Light"
+			tar zxf $CACHE_FILE -C $MQLIGHT_DATA_PATH
+                fi
+	fi
+	( set -x ; mqlight-config -v ; mqlight-config $CONFIG ;	mqlight-start --no-browser )
+}
+
+stop()
+{
+	mqlight-stop
+	dspmq
+	exit
+}
+
+case "$1" in
+	initialize)	initialize;;
+	runmqras)	runmqras;;
+	stop)		stop;;
+	start|*)	licenseCheck
+			config
+			start
+			trap stop SIGTERM SIGINT
+			monitor
+			;;
+esac


### PR DESCRIPTION
Cache IBM MQ Light appdata as a tar in /var/cache/ for to improve first
start time.
